### PR TITLE
Add hmcts config into renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
+    "local>hmcts/.github:renovate-config",
     "local>hmcts/common-performance//renovate/performance"
   ]
 }


### PR DESCRIPTION
Stop Jenkins failing as the hmcts config needs to belong in the repo not in the shared renovate config
